### PR TITLE
Ensure that the name of the team is randomly generated without odd UTF8 characters.

### DIFF
--- a/Rollbar-Teams-Team/docs/README.md
+++ b/Rollbar-Teams-Team/docs/README.md
@@ -37,7 +37,7 @@ _Required_: Yes
 
 _Type_: String
 
-_Maximum_: <code>32</code>
+_Pattern_: <code>^[a-zA-Z0-9\-\_ ]{1,32}$</code>
 
 _Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
 

--- a/Rollbar-Teams-Team/overrides.json
+++ b/Rollbar-Teams-Team/overrides.json
@@ -1,5 +1,0 @@
-{
-  "CREATE": {
-    "/Name": "Contract test team"
-  }
-}

--- a/Rollbar-Teams-Team/rollbar-teams-team.json
+++ b/Rollbar-Teams-Team/rollbar-teams-team.json
@@ -33,7 +33,7 @@
     "Name": {
       "description": "Name of the team. Max length 32 characters.",
       "type": "string",
-      "maxLength": 32
+      "pattern": "^[a-zA-Z0-9\\-\\_ ]{1,32}$"
     },
     "AccessLevel": {
       "description": "Can be standard, light, or view.",


### PR DESCRIPTION
Otherwise, Rollbar can be difficult with the eventual consistency if we try to create/delete a team with the same name over and over again.