### PR TITLE
Attempt to fix flake tests

### DIFF
--- a/Rollbar-Common/src/abstract-base-resource.test.ts
+++ b/Rollbar-Common/src/abstract-base-resource.test.ts
@@ -98,24 +98,27 @@ describe('AbstractBaseResource', () => {
             retries: number
         ) {
             initialSetup();
-            let firstProgressEvent = await handleFunctionName(session, request, {}, logger,typeConfiguration);
+            let firstProgressEvent = await handleFunctionName(session, request, {}, logger, typeConfiguration);
             expect(firstProgressEvent.status).toBe(OperationStatus.InProgress);
             expect(firstProgressEvent.callbackContext).toHaveProperty('retry', 1);
+            expect(firstProgressEvent.callbackDelaySeconds).toBeGreaterThanOrEqual(0);
 
             let callbackContext = firstProgressEvent.callbackContext;
 
             for (let i = 0; i < retries; i++) {
                 retrySetup();
-                let intermediateProgressEvent = await handleFunctionName(session, request, callbackContext, logger,typeConfiguration);
+                let intermediateProgressEvent = await handleFunctionName(session, request, callbackContext, logger, typeConfiguration);
                 expect(intermediateProgressEvent.status).toBe(OperationStatus.InProgress);
                 expect(intermediateProgressEvent.callbackContext).toHaveProperty('retry', i + 2);
+                expect(intermediateProgressEvent.callbackDelaySeconds).toBeGreaterThanOrEqual(0);
                 callbackContext = intermediateProgressEvent.callbackContext;
             }
 
             lastSetup();
-            let lastProgressEvent = await handleFunctionName(session, request, firstProgressEvent.callbackContext, logger,typeConfiguration);
+            let lastProgressEvent = await handleFunctionName(session, request, firstProgressEvent.callbackContext, logger, typeConfiguration);
             expect(lastProgressEvent.status).toBe(OperationStatus.Success);
             expect(lastProgressEvent.callbackContext).toBeUndefined();
+            expect(lastProgressEvent.callbackDelaySeconds).toBeGreaterThanOrEqual(0);
         }
 
         it.each([

--- a/Rollbar-Common/src/abstract-rollbar-resource.ts
+++ b/Rollbar-Common/src/abstract-rollbar-resource.ts
@@ -1,13 +1,50 @@
 import {
+    Action,
     BaseModel,
     exceptions,
-    ResourceHandlerRequest
+    handlerEvent,
+    LoggerProxy,
+    OperationStatus,
+    Optional,
+    ProgressEvent,
+    ResourceHandlerRequest,
+    SessionProxy
 } from "@amazon-web-services-cloudformation/cloudformation-cli-typescript-lib";
-import {AbstractBaseResource} from "./abstract-base-resource";
+import {AbstractBaseResource, RetryableCallbackContext} from "./abstract-base-resource";
 import {AxiosError} from "axios";
 import {ApiError} from "./rollbar-client";
+import {
+    ServiceInternalError
+} from "@amazon-web-services-cloudformation/cloudformation-cli-typescript-lib/dist/exceptions";
 
 export abstract class AbstractRollbarResource<ResourceModelType extends BaseModel, GetResponseData, CreateResponseData, UpdateResponseData, TypeConfigurationM> extends AbstractBaseResource<ResourceModelType, GetResponseData, CreateResponseData, UpdateResponseData, AxiosError<ApiError>, TypeConfigurationM> {
+
+    @handlerEvent(Action.Create)
+    async createHandler(session: Optional<SessionProxy>, request: ResourceHandlerRequest<ResourceModelType>, callbackContext: RetryableCallbackContext, logger: LoggerProxy, typeConfiguration: TypeConfigurationM): Promise<ProgressEvent<ResourceModelType, RetryableCallbackContext>> {
+        try {
+            return super.createHandler(session, request, callbackContext, logger, typeConfiguration);
+        } catch (e) {
+            return this.checkForTransientError(e, request, callbackContext);
+        }
+    }
+
+    @handlerEvent(Action.Update)
+    async updateHandler(session: Optional<SessionProxy>, request: ResourceHandlerRequest<ResourceModelType>, callbackContext: RetryableCallbackContext, logger: LoggerProxy, typeConfiguration: TypeConfigurationM): Promise<ProgressEvent<ResourceModelType, RetryableCallbackContext>> {
+        try {
+            return super.updateHandler(session, request, callbackContext, logger, typeConfiguration);
+        } catch (e) {
+            return this.checkForTransientError(e, request, callbackContext);
+        }
+    }
+
+    @handlerEvent(Action.Delete)
+    async deleteHandler(session: Optional<SessionProxy>, request: ResourceHandlerRequest<ResourceModelType>, callbackContext: RetryableCallbackContext, logger: LoggerProxy, typeConfiguration: TypeConfigurationM): Promise<ProgressEvent<ResourceModelType, RetryableCallbackContext>> {
+        try {
+            return super.deleteHandler(session, request, callbackContext, logger, typeConfiguration);
+        } catch (e) {
+            return this.checkForTransientError(e, request, callbackContext);
+        }
+    }
 
     processRequestException(e: AxiosError<ApiError>, request: ResourceHandlerRequest<ResourceModelType>) {
         const apiError = e.response?.data;
@@ -28,14 +65,30 @@ export abstract class AbstractRollbarResource<ResourceModelType extends BaseMode
             case 404:
                 throw new exceptions.NotFound(this.typeName, request.logicalResourceIdentifier);
             case 413:
-                throw new exceptions.ServiceInternalError(`Request exceeds the maximum size of 128KB: ${errorMessage}`);
+                throw new exceptions.InvalidRequest(`Request exceeds the maximum size of 128KB: ${errorMessage}`);
             case 422:
-                throw new exceptions.ServiceInternalError(`The request was parseable (i.e. valid JSON), but some parameters were missing or otherwise invalid: ${errorMessage}`);
+                throw new exceptions.InvalidRequest(`The request was parseable (i.e. valid JSON), but some parameters were missing or otherwise invalid: ${errorMessage}`);
             case 429:
                 throw new exceptions.ServiceLimitExceeded(errorMessage);
             default:
-                throw new exceptions.InternalFailure(`Unexpected error occurred, see serialized exception below:\n${errorMessage}`);
+                throw new exceptions.ServiceInternalError(`Unexpected error occurred:\n${errorMessage}`);
         }
+    }
+
+    // When performing actions (i.e. create/update/delete) Rollbar returns sometimes 500 errors with a message
+    // saying to try again later. So that's what we are doing here by replaying the same event and callback context that
+    // we got this time around.
+    checkForTransientError(e: Error, request: ResourceHandlerRequest<ResourceModelType>, callbackContext: RetryableCallbackContext) {
+        if (e instanceof ServiceInternalError && e.message.match(/please try again/i)) {
+            const maxDelay = Math.pow(2, callbackContext.retry || 1) * Math.random();
+            return ProgressEvent.builder<ProgressEvent<ResourceModelType, RetryableCallbackContext>>()
+                .status(OperationStatus.InProgress)
+                .resourceModel(request.desiredResourceState)
+                .callbackContext(callbackContext)
+                .callbackDelaySeconds(maxDelay * Math.random())
+                .build();
+        }
+        throw e;
     }
 
 }


### PR DESCRIPTION
This add 2 things that should hopefully fix the flakiness of the contract tests:
- exponential backoff for "IN_PROGRESS" progress events
- catch of transient errors from Rollbar to replay the progress events